### PR TITLE
fix: Force Babel to always compile in ESM mode.

### DIFF
--- a/packages/nimbus/bin/nimbus-setup
+++ b/packages/nimbus/bin/nimbus-setup
@@ -86,6 +86,7 @@ function addScriptsToPackage(response) {
 
   if (drivers.includes('webpack')) {
     scripts.build = 'NODE_ENV=production nimbus webpack';
+    scripts.start = 'nimbus create-config webpack --silent && nimbus-webpack-server';
 
     delete scripts.prebuild;
     delete scripts.postbuild;

--- a/packages/nimbus/index.js
+++ b/packages/nimbus/index.js
@@ -100,6 +100,10 @@ module.exports = function cli(tool) {
 
     if (usingBabel) {
       driver.options.dependencies.push('babel');
+
+      // Babel 7.5 handles dynamic imports natively, which will break Webpack
+      // when transforming to `commonjs`. So always force Babel to ESM mode.
+      process.env.ESM = 'true';
     }
 
     if (usingTypeScript) {


### PR DESCRIPTION
Our webpack bundle has been generating a 5MB chunk for quite some time now. Turns out Babel 7.5 changed the way dynamic imports were compiled, which broke our bundle splitting. To fix this, Babel must be ran using ES modules, so set the flag.