### PR TITLE
fix: Only generate `tsconfig.eslint.json` if project is TS enabled.

### DIFF
--- a/packages/nimbus/index.js
+++ b/packages/nimbus/index.js
@@ -77,6 +77,10 @@ module.exports = function cli(tool) {
 
   // Create a specialized tsconfig for ESLint
   tool.getPlugin('driver', 'eslint').onCreateConfigFile.listen(context => {
+    if (!usingTypeScript) {
+      return;
+    }
+
     const configPath = path.join(process.cwd(), 'tsconfig.eslint.json');
     const include = [`${typesFolder}/**/*`]; // Always allow global types
     let extendsFrom = './tsconfig.json';

--- a/packages/nimbus/templates/project/dotfiles/gitignore.ejs
+++ b/packages/nimbus/templates/project/dotfiles/gitignore.ejs
@@ -11,12 +11,12 @@ logs/
 # Cache
 .axe/
 .bundle/
-.eslintcache/
 .happo/
 .idea/
 .npm/
 .vagrant/
 .vscode/
+.eslintcache
 .yarnclean
 
 # Directories


### PR DESCRIPTION
to: @hayes 

Title says it all. Also fixed `.eslintcache` since it's a file not a folder.