### PR TITLE
fix: Improve global and Node integration.

### DIFF
--- a/.github/workflows/require.yml
+++ b/.github/workflows/require.yml
@@ -11,6 +11,8 @@ jobs:
           node-version: 12
       - name: Setup
         run: yarn install --frozen-lockfile --ignore-engines
+      - name: Build
+        run: yarn run build
       - name: Run Danger CI
         run: yarn danger ci --use-github-checks
         env:

--- a/packages/config-eslint/index.js
+++ b/packages/config-eslint/index.js
@@ -6,6 +6,7 @@ const { IGNORE_PATHS } = require('@airbnb/nimbus-common/constants');
 /**
  * @typedef {object} ConfigOptions
  * @property {boolean} [next]
+ * @property {boolean} [node]
  * @property {boolean} [prettier]
  * @property {boolean} [typescript]
  */
@@ -26,6 +27,7 @@ function fromHere(filePath) {
  */
 exports.getExtendsList = function getExtendsList({
   next = false,
+  node = false,
   prettier = false,
   typescript = false,
 }) {
@@ -41,7 +43,12 @@ exports.getExtendsList = function getExtendsList({
     paths.push(fromHere('presets/typescript.js'));
   }
 
-  // Prettier
+  // Node
+  if (node) {
+    paths.push(fromHere('presets/node.js'));
+  }
+
+  // Prettier (must be last)
   if (prettier) {
     paths.push(fromHere('presets/prettier.js'));
 

--- a/packages/config-eslint/presets/base.js
+++ b/packages/config-eslint/presets/base.js
@@ -21,8 +21,13 @@ module.exports = {
 
   globals: {
     __DEV__: 'readonly',
-    jsdom: 'readonly',
+    // Metrics and analytics providers
+    ga: 'readonly',
     newrelic: 'readonly',
+    // Mostly for easier compatibility between browsers, workers, etc
+    global: 'readonly',
+    // Mostly references to `process.env.NODE_ENV`
+    process: 'readonly',
   },
 
   env: {
@@ -55,6 +60,9 @@ module.exports = {
     {
       files: [`*.test.${EXTS_GROUP}`],
       plugins: ['jest'],
+      globals: {
+        jsdom: 'readonly',
+      },
       env: {
         jest: true,
         node: true,

--- a/packages/config-eslint/presets/node.js
+++ b/packages/config-eslint/presets/node.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    browser: false,
+    node: true,
+  },
+};

--- a/packages/nimbus/configs/eslint.js
+++ b/packages/nimbus/configs/eslint.js
@@ -4,11 +4,12 @@ const { getExtendsList, getIgnoreList } = require('@airbnb/config-eslint');
 const { getSettings } = require('@airbnb/nimbus-common');
 
 const { tool } = process.beemo;
-const { next } = getSettings();
+const { next, node } = getSettings();
 
 module.exports = {
   extends: getExtendsList({
     next,
+    node,
     prettier: tool.isPluginEnabled('driver', 'prettier'),
     typescript: tool.isPluginEnabled('driver', 'typescript'),
   }),


### PR DESCRIPTION
to: @hayes 

At the moment, browser code errors on usage of `process` and `global`, which we primarily use for referencing `NODE_ENV` and `global.location` (etc) respectively.

Also, when the `node` setting is true, we don't actually enable the node env, which this now does.