### PR TITLE
fix: Webpack manifest plugin.

### DIFF
--- a/packages/config-webpack/src/plugins/InlineManifestPlugin.ts
+++ b/packages/config-webpack/src/plugins/InlineManifestPlugin.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable no-param-reassign, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, import/no-extraneous-dependencies */
 
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import sourceMappingURL from 'source-map-url';

--- a/packages/config-webpack/src/plugins/InlineManifestPlugin.ts
+++ b/packages/config-webpack/src/plugins/InlineManifestPlugin.ts
@@ -1,8 +1,8 @@
-/* eslint-disable no-param-reassign, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, import/no-extraneous-dependencies */
+/* eslint-disable no-param-reassign, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 
-import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import sourceMappingURL from 'source-map-url';
+import webpack from 'webpack';
 
 function getAssetName(chunks: webpack.compilation.Chunk[], chunkName: string) {
   return chunks.filter((chunk) => chunk.name === chunkName)?.[0]?.files[0];
@@ -22,7 +22,7 @@ function inlineWhenMatched(
     if (isManifestScript) {
       return {
         tagName: 'script',
-        voidTag: true,
+        voidTag: false,
         attributes: {
           type: 'text/javascript',
         },


### PR DESCRIPTION
Fix void tag which throws an error when setting to true.
```js
Uncaught SyntaxError: Unexpected token '<'
```