### PR TITLE
new(config-babel): allow override of ignore

### DIFF
--- a/packages/config-babel/src/index.ts
+++ b/packages/config-babel/src/index.ts
@@ -10,6 +10,7 @@ interface BabelOptions {
   node?: boolean;
   react?: boolean;
   typescript?: boolean;
+  ignore?: string[];
 }
 
 /**
@@ -24,6 +25,7 @@ export function getConfig({
   node = false,
   react = false,
   typescript = false,
+  ignore = [...IGNORE_PATHS, '__tests__', '__mocks__'],
 }: BabelOptions): BabelConfig {
   const envOptions = {
     loose: true,
@@ -104,7 +106,7 @@ export function getConfig({
   }
 
   return {
-    ignore: [...IGNORE_PATHS, '__tests__', '__mocks__'],
+    ignore,
     plugins,
     presets,
   };


### PR DESCRIPTION
We have an issue where we need to allow babel-parsing of one or more packages from `node_modules/`, but we cannot currently override this because `ignore` cannot be affected using babel `overrides` or `exclude`.

This adds a hook to customize the `ignore` list but shouldn't change existing behavior.

@etr2460 @kristw @hayes 