### PR TITLE
fix: use envOptions.loose for ESNext babel plugins

### DIFF
--- a/packages/config-babel/src/index.ts
+++ b/packages/config-babel/src/index.ts
@@ -100,7 +100,9 @@ export function getConfig({
   }
 
   if (useNext) {
-    plugins.push('@babel/plugin-proposal-class-properties');
+    plugins.push(['@babel/plugin-proposal-class-properties', { loose: envOptions.loose }]);
+    plugins.push(['@babel/plugin-proposal-private-methods', { loose: envOptions.loose }];
+    plugins.push(['@babel/plugin-proposal-private-property-in-object', { loose: envOptions.loose }];
   }
 
   return {


### PR DESCRIPTION
According to Babel documentation, the `loose` mode configuration must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object.

Ref: https://babeljs.io/docs/en/babel-plugin-proposal-private-methods#loose